### PR TITLE
addressed warnings 'SUPPORT_TARGET_TEMPERATURE was used from tuya_sma…

### DIFF
--- a/custom_components/tuya_smart_ir_ac/climate.py
+++ b/custom_components/tuya_smart_ir_ac/climate.py
@@ -11,8 +11,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.climate.const import (
     HVACMode,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_FAN_MODE,
+    ClimateEntityFeature,				 
 )
 from homeassistant.const import UnitOfTemperature, STATE_UNKNOWN
 from homeassistant.components.climate import ClimateEntity
@@ -60,6 +59,8 @@ def setup_platform(
 
 
 class TuyaThermostat(ClimateEntity):
+    _enable_turn_on_off_backwards_compatibility = False
+    
     def __init__(self, climate, hass):
         _LOGGER.info(pformat(climate))
         self._api = TuyaAPI(
@@ -86,7 +87,12 @@ class TuyaThermostat(ClimateEntity):
 
     @property
     def supported_features(self):
-        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
+        return (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
+        )
 
     @property
     def min_temp(self):

--- a/custom_components/tuya_smart_ir_ac/climate.py
+++ b/custom_components/tuya_smart_ir_ac/climate.py
@@ -175,5 +175,5 @@ class TuyaThermostat(ClimateEntity):
                     if self._api._power == "0":
                         await self._api.async_turn_on()
                     await self._api.async_set_fan_speed(0)
-                    await self._api.async_set_hvac_mode(mode)
+                    await self._api.async_set_hvac_mode(hvac_mode)
                 break

--- a/custom_components/tuya_smart_ir_ac/climate.py
+++ b/custom_components/tuya_smart_ir_ac/climate.py
@@ -72,6 +72,7 @@ class TuyaThermostat(ClimateEntity):
         )
         self._sensor_name = climate[SENSOR]
         self._name = climate[NAME]
+        self._unique_id = climate[AC_ID]
 
     @property
     def name(self):
@@ -79,7 +80,7 @@ class TuyaThermostat(ClimateEntity):
 
     @property
     def unique_id(self):
-        return "tuya_hack_01"
+        return self._unique_id
 
     @property
     def temperature_unit(self):


### PR DESCRIPTION
…rt_ir_ac, this is a deprecated constant', 'SUPPORT_FAN_MODE was used from tuya_smart_ir_ac, this is a deprecated constant', 'Entity None (<class 'custom_components.tuya_smart_ir_ac.climate.TuyaThermostat'>) implements HVACMode(s): cool, heat, auto, fan_only, dry, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature'